### PR TITLE
Proposal for a README template

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,48 @@
+# PROJECT NAME
+
+Brief description. Provide:
+
+- context
+- what it does
+- who is it for
+- why one would use it
+
+Any details requiring more than three short paragraphs should go in a separate document (typically a white paper).
+
+## Pre-requisites
+
+Describe pre-requisites, in particular:
+
+- skills, experience level
+- deployment (browser, mobile, desktop, cloud...)
+- operating system
+- tools, runtimes (e.g. node.js, nix, ...)
+
+## Getting started
+
+How to:
+
+- download or clone
+- install
+- start or run
+
+## Usage
+
+A few basic examples of how to use (not a complete reference).
+
+## See Also
+
+- link(s) to more detailed project documents
+- License: see LICENSE
+- Contributing: see CONTRIBUTING.md
+- Security: see SECURITY.md
+- Other projects by [HAL][HAL]
+- Other projects by the [Cardano Foundation][CF]
+- About [Cardano][Cardano]
+
+<!-- MARKDOWN LINKS & IMAGES -->
+
+[HAL]: https://github.com/cardano-foundation/hal
+[CF]: https://github.com/cardano-foundation
+[Cardano]: https://cardano.org/
+


### PR DESCRIPTION
I think it would be nice if all our README's followed the same template.

The README should be fairly short but also complete (where necessary by linking to other, more detailed, documents).

This template (and others) can go in a ./templates directory of our team (hal) repo.