### PR TITLE
chore: bump mpfs to v1.2.0

### DIFF
--- a/infrastructure/mpfs/docker-compose.yml
+++ b/infrastructure/mpfs/docker-compose.yml
@@ -120,7 +120,7 @@ services:
       - yaci-store-db-preprod
 
   mpfs:
-    image: ghcr.io/cardano-foundation/mpfs/mpfs:v1.1.1
+    image: ghcr.io/cardano-foundation/mpfs/mpfs:v1.2.0
     healthcheck:
       test: ["CMD-SHELL", "curl -s localhost:3000/tokens | jq -e '.indexerStatus.indexerTip == .indexerStatus.networkTip'"]
       interval: 10s


### PR DESCRIPTION
Bumps the deployed MPFS image to `v1.2.0`, which closes:

- #14 — structured JSON logging across HTTP / indexer / tx-build, with request_id and txid correlation
- #15 — auto-evaluate plutus exec units via ogmios in the tx builder; fixes IsValid mismatch on tokens whose trie depth pushed per-request cost above the previous hardcoded 100M-step ceiling (live repro on cfhal token, ~970 facts)

Release: https://github.com/cardano-foundation/mpfs/releases/tag/v1.2.0
Image:   ghcr.io/cardano-foundation/mpfs/mpfs:v1.2.0

The image was already rolled live on the host; this PR brings the
compose source-of-truth in sync.