### PR TITLE
fix(agent): set C.UTF-8 locale to avoid hGetContents byte-226 crash

### DIFF
--- a/infrastructure/moog/agent/docker-compose.yaml
+++ b/infrastructure/moog/agent/docker-compose.yaml
@@ -7,6 +7,8 @@ services:
       - source: docker
         target: /run/secrets/docker/config.json
     environment:
+      - LANG=C.UTF-8
+      - LC_ALL=C.UTF-8
       - MOOG_MPFS_HOST=http://10.1.21.21:3000
       - MOOG_WALLET_FILE=/run/secrets/agent-wallet
       - MOOG_TOKEN_ID=21c523c3b4565f1fc1ad7e54e82ca976f60997d8e7e9946826813fabf341069b


### PR DESCRIPTION
The Haskell moog-agent crashes with:

```
moog-agent: fd:9: hGetContents: invalid argument
            (cannot decode byte sequence starting from 226)
```

every time it reads child-process output containing a non-ASCII byte.
The container's default locale is `C` (ASCII), so any byte ≥ 0x80
trips Haskell's locale-aware text decoder and kills the process.
Docker restarts it; same line of input crashes it again. Crash loop.

Setting `LANG=C.UTF-8` and `LC_ALL=C.UTF-8` forces the UTF-8 decoder,
which accepts the high-bit bytes encountered in practice.

This is the same fix that stabilised the oracle a few weeks ago.

Verified live: after applying, the agent polled MPFS cleanly, picked
up a pending test-run, and stayed up (RC=0, no more crashes).