### PR TITLE
chore(mpfs): bump to v1.3.0 (cardano-foundation/mpfs#21 merged)

### DIFF
--- a/infrastructure/mpfs/docker-compose.yml
+++ b/infrastructure/mpfs/docker-compose.yml
@@ -120,7 +120,7 @@ services:
       - yaci-store-db-preprod
 
   mpfs:
-    image: ghcr.io/cardano-foundation/mpfs/mpfs:v1.2.0
+    image: ghcr.io/cardano-foundation/mpfs/mpfs:v1.3.0
     healthcheck:
       test: ["CMD-SHELL", "curl -s localhost:3000/tokens | jq -e '.indexerStatus.indexerTip == .indexerStatus.networkTip'"]
       interval: 10s


### PR DESCRIPTION
Bumps `infrastructure/mpfs/docker-compose.yml` to `ghcr.io/cardano-foundation/mpfs/mpfs:v1.3.0`, the proper release tag for [cardano-foundation/mpfs#21](https://github.com/cardano-foundation/mpfs/pull/22) (merged + released today).

Both production hosts are already running this image:
- `mpfs.plutimus.com` — rolled via `paolino/infrastructure`.
- cf-systems internal MPFS (`10.1.21.21:3000`) — the file under `/opt/hal/infrastructure/mpfs/docker-compose.yml` was sed-edited in place during the live-preprod smoke earlier today. This PR catches the git source up to what's running.

Release notes: https://github.com/cardano-foundation/mpfs/releases/tag/v1.3.0