### PR TITLE
feat(gatus): node head freshness check on mpfs

### DIFF
--- a/infrastructure/gatus/mpfs/config.yaml
+++ b/infrastructure/gatus/mpfs/config.yaml
@@ -42,3 +42,17 @@ endpoints:
       - "[BODY].status == UP"
     alerts:
       - type: telegram
+
+  # Node head freshness, anchored to wall-clock. networkSynchronization drops
+  # below 1 when the node stops following the chain (e.g. an obsolete node after
+  # a protocol-version hard fork). Distinct from "MPFS synced", whose
+  # indexerTip == networkTip stays true when the node tip freezes.
+  - name: Cardano node head
+    url: http://localhost:1337/health
+    interval: 60s
+    conditions:
+      - "[STATUS] == 200"
+      - "[BODY].connectionStatus == connected"
+      - "[BODY].networkSynchronization == 1"
+    alerts:
+      - type: telegram


### PR DESCRIPTION
Adds a Gatus check that alerts when the preprod cardano-node stops following the chain.

## Why

On 2026-06-10 ~02:11 UTC preprod hard-forked to protocol version 11. The mpfs box ran cardano-node 10.5.1 (PV10 only), which became an `ObsoleteNode` and froze at the last pre-fork block. node → ogmios → yaci-store → mpfs all stalled, the moog oracle (which reads the mpfs box) saw no requests, and the scheduled Antithesis runs failed for ~8h with no alert.

The existing **MPFS synced** check compares `indexerTip == networkTip` — but both freeze together when the node stalls, so it stays green. Nothing was anchored to wall-clock.

## What

New **Cardano node head** endpoint on `ogmios /health`, asserting `connectionStatus == connected` and `networkSynchronization == 1`. `networkSynchronization` is wall-clock-anchored, so it drops below 1 the moment the node stops advancing — catching obsolete-node / stalled-tip conditions the other checks miss.

Already applied to the deployed config on the mpfs box; Gatus validated 4 endpoints and the check is live.