### PR TITLE
fix(mpfs): bump preprod node to 11.0.1 + relax mpfs healthcheck

### DIFF
--- a/infrastructure/mpfs/docker-compose.yml
+++ b/infrastructure/mpfs/docker-compose.yml
@@ -11,7 +11,7 @@ services:
 
   cardano-node-preprod:
     container_name: cardano-node-preprod
-    image: ghcr.io/intersectmbo/cardano-node:10.5.1
+    image: ghcr.io/intersectmbo/cardano-node:11.0.1
     environment:
       CARDANO_NODE_SOCKET_PATH: /ipc/node-socket
     volumes:
@@ -122,7 +122,7 @@ services:
   mpfs:
     image: ghcr.io/cardano-foundation/mpfs/mpfs:v1.3.0
     healthcheck:
-      test: ["CMD-SHELL", "curl -s localhost:3000/tokens | jq -e '.indexerStatus.indexerTip == .indexerStatus.networkTip'"]
+      test: ["CMD-SHELL", "curl -fsS localhost:3000/tokens >/dev/null"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Reconciles the deployed `/opt/hal` mpfs compose with the repo. Both changes are already live on the mpfs box.

## node 10.5.1 → 11.0.1
Preprod hard-forked to **protocol version 11** on 2026-06-10 ~02:11 UTC. cardano-node 10.5.1 only speaks PV10, became an `ObsoleteNode`, and froze at the last pre-fork block (4805012). That stalled ogmios → yaci-store → mpfs, so the moog oracle (which reads this box) saw no requests and the scheduled Antithesis runs failed for hours. 11.0.1 is the current latest and follows the fork (already proven on the production `plutimus.com` preprod node).

## mpfs healthcheck → liveness probe
Switched from the strict `indexerTip == networkTip` equality to `curl -fsS localhost:3000/tokens >/dev/null`. The equality marks mpfs unhealthy whenever it is merely catching up, which `autoheal` then restarts. This relaxed probe was already deployed (a `docker-compose.yml.bak.healthcheck-strict` backup exists on the box); this PR just brings it into the repo.

Paired with #26 (gatus node-head freshness check), which alerts on exactly the stalled-node condition that went unnoticed here.