### PR TITLE
docs: align README and infrastructure docs with code, add agent layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# Repository Agent Guide
+
+## What this repo is
+
+The team repository of the High Assurance Lab (HAL) at the Cardano Foundation. It holds cross-project artifacts — the team handbook and process documents, weekly/monthly meeting notes, ZKP learning material, a README template — and the Docker Compose configuration for the team's preprod infrastructure (MPFS stack, Moog agent and oracle, Gatus monitoring). Product code lives in the project repositories listed in the [README](README.md#projects), not here.
+
+## How to work here
+
+- There is nothing to build or test: the repository is markdown plus deployment configuration. No CI runs on it.
+- Changes follow the [handbook Git workflow](docs/handbook.md#git-workflow): short-lived branch off `main`, PR, review. Documentation-only changes may be committed directly to `main`.
+- The compose files under `infrastructure/` are deployed on CF hosts from `/opt/hal`; do not run them locally — they mount host paths and secret files that only exist on those hosts.
+- When verifying claims about the deployments, read the compose files (`infrastructure/*/docker-compose.y*ml`), not only the READMEs.
+
+## Skills
+
+Activatable procedures live under `skills/`. Load the one whose description matches your task:
+
+- `skills/hal-guide/` — repository map, infrastructure layout, and where answers live; load it when asked anything about this repo, the HAL team, or its preprod deployments.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,20 @@
 # High-Assurance Lab Team
 
-This repository contains documentation, reports, plans, roadmaps, and more generally all kind of artifacts related to the _High Assurance Lab_ team at the [Cardano Foundation](https://cardano.org) which are cutting across other projects boundaries.
+High Assurance Lab team repository.
 
-## Links
+## What is this
 
-* [Roadmap](https://github.com/orgs/cardano-foundation/projects/27/views/1)
-* [Weekly meetings](docs/weekly)
-* [Handbook](docs/handbook.md)
-* [Cryptography prerequisites for ZKP](docs/crypto/gitbook.md)
+This repository contains documentation, reports, plans, roadmaps, and more generally all kind of artifacts related to the _High Assurance Lab_ (HAL) team at the [Cardano Foundation](https://cardano.org) which are cutting across other projects' boundaries.
+
+Concretely, it holds:
+
+- the team [handbook](docs/handbook.md) and process documents ([asynchronous communication](docs/async.md), [interviews](docs/interviews.md), the [Radicle evaluation](docs/radicle.md), [Homebrew packaging notes](docs/homebrew.md));
+- [weekly](docs/weekly) and [monthly](docs/monthly) meeting notes and reports;
+- cryptography learning material for ZKP ([gitbook](docs/crypto/gitbook.md), [journal](docs/crypto/journal.md), training slides);
+- the [infrastructure](infrastructure) configuration for the team's preprod deployments (MPFS stack, Moog agent and oracle, Gatus monitoring);
+- a [README template](templates/README.md) for new projects.
+
+Code for the team's products lives in the project repositories listed below, not here.
 
 ## Projects
 
@@ -24,16 +31,61 @@ Each project's status is identified by an icon:
 
 | Project                   | Comment                                                                 | Status | Version                                                                                      | URL                                                                     |
 |---------------------------|-------------------------------------------------------------------------|--------|----------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
-| `cardano-wallet`          | Historically the main focus of the team                                 | 🔒     | [v2025-03-31](https://github.com/cardano-foundation/cardano-wallet/releases/tag/v2025-03-31) | [github](https://github.com/cardano-foundation/cardano-wallet)          |
+| `cardano-wallet`          | Historically the main focus of the team                                 | 🔒     | [v2026-05-11](https://github.com/cardano-foundation/cardano-wallet/releases/tag/v2026-05-11) | [github](https://github.com/cardano-foundation/cardano-wallet)          |
 | `cardano-wallet-agda`     | Formal specification for some wallet features                           | 🔒     |                                                                                              | [github](https://github.com/cardano-foundation/cardano-wallet-agda)     |
-| `cardano-addresses`       | CLI tool for addresses and mnemonic manipulation & derivations          | 🚢     | [4.0.1](https://github.com/IntersectMBO/cardano-addresses/releases/tag/4.0.1)                | [github](https://github.com/IntersectMBO/cardano-addresses)             |
+| `cardano-addresses`       | CLI tool for addresses and mnemonic manipulation & derivations          | 🚢     | [4.0.5](https://github.com/IntersectMBO/cardano-addresses/releases/tag/4.0.5)                | [github](https://github.com/IntersectMBO/cardano-addresses)             |
 | `cardano-crypto`          | Library for low-level crypto                                            | 🔒     |                                                                                              | [github](https://github.com/IntersectMBO/cardano-crypto)                |
-| `moog`                    | Antithesis CLI client  for Cardano ecosystem                            | 🚢     | [v0.4.1.1](https://github.com/cardano-foundation/moog/releases/tag/v0.4.1.1)                 | [github](https://github.com/cardano-foundation/moog)                    |
-| `mpfs`                    | Merkle-Patricia-Forestry generic service                                | 🚧     |                                                                                              | [github](https://github.com/cardano-foundation/mpfs)                    |
+| `moog`                    | Antithesis CLI client  for Cardano ecosystem                            | 🚢     | [v0.5.1.5](https://github.com/cardano-foundation/moog/releases/tag/v0.5.1.5)                 | [github](https://github.com/cardano-foundation/moog)                    |
+| `mpfs`                    | Merkle-Patricia-Forestry generic service                                | 🚧     | [v1.3.0](https://github.com/cardano-foundation/mpfs/releases/tag/v1.3.0)                     | [github](https://github.com/cardano-foundation/mpfs)                    |
 | `cardano-deposit-wallet`  | Safer and faster experimental wallet                                    | 💀     |                                                                                              | [github](https://github.com/cardano-foundation/cardano-deposit-wallet)  |
-| `pop`                     | Track software lifecycle on Cardano, related to `mpfs` and `antithesis` | 💡     |                                                                                              | [github](https://github.com/cardano-scaling/pop)                        |
+| `pop`                     | Track software lifecycle on Cardano (repository archived)               | 💀     |                                                                                              | [github](https://github.com/cardano-scaling/pop)                        |
 | `vrf`                     | Library for VRF crypto                                                  | 🚧     |                                                                                              | [github](https://github.com/txpipe/vrf)                                 |
 | `kes`                     | Library for KES crypto                                                  | 🚧     |                                                                                              | [github](https://github.com/txpipe/kes)                                 |
 | `cardano-wallet-client`   |                                                                         | 💀     |                                                                                              | [github](https://github.com/cardano-foundation/cardano-wallet-client)   |
 | `amaru`                   | Rust Cardano node                                                       | 🚧     |                                                                                              | [github](https://github.com/pragma-org/amaru)                           |
 | `cardano-node-antithesis` | Testing the Haskell cardano node                                        | 🚧     |                                                                                              | [github](https://github.com/cardano-foundation/cardano-node-antithesis) |
+
+## Architecture
+
+The only runnable artifact in this repository is the deployment configuration under [infrastructure/](infrastructure), which runs the team's preprod MPFS service and the Moog agent and oracle that consume it:
+
+```mermaid
+flowchart LR
+    subgraph mpfs_host["MPFS host"]
+        node["cardano-node (preprod)"]
+        ogmios["Ogmios"]
+        yaci["Yaci Store"]
+        pg[("PostgreSQL")]
+        mpfs["MPFS :3000"]
+        node -- "node.socket" --> ogmios
+        node -- "chain sync" --> yaci
+        yaci --> pg
+        mpfs -- "UTxO queries" --> yaci
+        mpfs -- "tx submission" --> ogmios
+    end
+    subgraph agent_host["Agent host"]
+        agent["moog-agent"]
+    end
+    subgraph oracle_host["Oracle host"]
+        oracle["moog-oracle"]
+    end
+    agent -- "HTTP :3000" --> mpfs
+    oracle -- "HTTP :3000" --> mpfs
+    monitoring["Gatus (one per host)"] -. "alerts" .-> telegram["Telegram"]
+```
+
+See [infrastructure/README.md](infrastructure/README.md) for the per-host details.
+
+## Documentation
+
+* [Roadmap](https://github.com/orgs/cardano-foundation/projects/27/views/1)
+* [Handbook](docs/handbook.md) — how the team works
+* [Weekly meetings](docs/weekly)
+* [Cryptography prerequisites for ZKP](docs/crypto/gitbook.md)
+* [Infrastructure](infrastructure/README.md) — preprod deployments and monitoring
+
+For AI agents, start at [AGENTS.md](AGENTS.md).
+
+## Development
+
+This is a documentation and configuration repository: there is nothing to build. Changes follow the [Git workflow described in the handbook](docs/handbook.md#git-workflow); documentation-only changes may be committed directly to `main`. New project READMEs should follow the [template](templates/README.md).

--- a/docs/deployment/anti-services.md
+++ b/docs/deployment/anti-services.md
@@ -1,3 +1,7 @@
+# Anti services (historical)
+
+> **Superseded.** This page describes the deployment of the `anti` services, since renamed to [Moog](https://github.com/cardano-foundation/moog). The current deployments live in [infrastructure/moog/](../../infrastructure/moog) (compose files pinned to released images, run from `/opt/hal`) — see [infrastructure/README.md](../../infrastructure/README.md). The `rad push` step predates the [November 2025 decision to stop using Radicle](../radicle.md#november-2025-decision). The `.ssh/config` stanzas below are still the way to reach the hosts.
+
 ## Building service images
 
 To build the docker images, the supported way involve nix. Luckily the builder machines are nix-cached already

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,68 @@
+# HAL Infrastructure
+
+Deployment configuration for the team's preprod services. Three hosts on CF infrastructure each run a Docker Compose stack from a checkout of this repository at `/opt/hal`:
+
+| Host | Address | Stack | Directory |
+|------|---------|-------|-----------|
+| MPFS | 10.1.21.21 | cardano-node + Ogmios + Yaci Store + MPFS, Gatus, node currency check | [mpfs/](mpfs), [gatus/mpfs/](gatus/mpfs), [scripts/](scripts) |
+| Agent | 10.1.21.20 | Moog agent, Gatus | [moog/agent/](moog/agent), [gatus/agent/](gatus/agent) |
+| Oracle | 10.1.21.19 | Moog oracle, Gatus | [moog/oracle/](moog/oracle), [gatus/oracle/](gatus/oracle) |
+
+SSH access goes through the CF jumpbox; see [docs/deployment/anti-services.md](../docs/deployment/anti-services.md) for the `.ssh/config` stanzas.
+
+## Architecture
+
+```mermaid
+flowchart TB
+    subgraph mpfs_host["MPFS host (10.1.21.21)"]
+        node["cardano-node-preprod 11.0.1"]
+        ogmios["ogmios-preprod v6.14.0<br/>127.0.0.1:1337"]
+        yaci["yaci-store-preprod 2.0.0-beta4<br/>127.0.0.1:8080"]
+        pg[("yaci-store-db-preprod<br/>postgres 17.4")]
+        mpfs["mpfs v1.3.0<br/>0.0.0.0:3000"]
+        gatusm["gatus :8090"]
+        cron["node-currency-check.sh (cron)"]
+        node -- "node.socket" --> ogmios
+        node -- "chain sync + node.socket" --> yaci
+        yaci -- "JDBC" --> pg
+        yaci -- "tx submission" --> ogmios
+        mpfs -- "HTTP :8080" --> yaci
+        mpfs -- "HTTP :1337" --> ogmios
+    end
+    subgraph agent_host["Agent host (10.1.21.20)"]
+        agent["moog-agent v0.4.1.2"]
+        gatusa["gatus"]
+    end
+    subgraph oracle_host["Oracle host (10.1.21.19)"]
+        oracle["moog-oracle v0.4.1.2"]
+        gatuso["gatus"]
+    end
+    agent -- "HTTP 10.1.21.21:3000" --> mpfs
+    oracle -- "HTTP 10.1.21.21:3000" --> mpfs
+    agent -- "host Docker daemon" --> anti["Antithesis registry"]
+    gatusm -.-> telegram["Telegram"]
+    gatusa -.-> telegram
+    gatuso -.-> telegram
+    cron -.-> telegram
+```
+
+## Components
+
+### [mpfs/](mpfs)
+
+The preprod [MPFS](https://github.com/cardano-foundation/mpfs) stack: a `cardano-node` following preprod, [Ogmios](https://ogmios.dev) for transaction submission, [Yaci Store](https://github.com/bloxbean/yaci-store) (backed by PostgreSQL) as UTxO indexer, and the MPFS service itself, published on port 3000. An `autoheal` container restarts anything whose healthcheck fails. See [mpfs/README.md](mpfs/README.md) for setup, including the Mithril snapshot bootstrap.
+
+### [moog/](moog)
+
+The [Moog](https://github.com/cardano-foundation/moog) agent and oracle deployments, each a single-service compose file pinned to a released Moog image. Both reach MPFS at `http://10.1.21.21:3000` and load their wallets and secrets from files on the host. See [moog/agent/README.md](moog/agent/README.md) and [moog/oracle/README.md](moog/oracle/README.md).
+
+### [gatus/](gatus)
+
+One [Gatus](https://github.com/TwiN/gatus) instance per host, alerting to Telegram (credentials from `/home/paolino/secrets/gatus/.env`, defining `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID`):
+
+- `gatus/mpfs` (web UI on port 8090, to avoid clashing with Yaci Store on 8080) checks that MPFS answers `/tokens` **and** its indexer tip equals the network tip, that Ogmios is healthy and fully synchronized, that Yaci Store's actuator reports UP, and that the node head is fresh (`networkSynchronization == 1` — catches a node frozen by a hard fork).
+- `gatus/agent` and `gatus/oracle` check that MPFS is reachable from their respective hosts.
+
+### [scripts/](scripts)
+
+[`node-currency-check.sh`](scripts/node-currency-check.sh) is a cron-driven companion to the Gatus node-head check: it compares the image tags of running `cardano-node` containers against the latest IntersectMBO release and warns on Telegram *before* an outdated node freezes at a preprod/preview hard fork. It alerts only when the situation changes, so a daily cron does not spam.

--- a/infrastructure/moog/agent/README.md
+++ b/infrastructure/moog/agent/README.md
@@ -1,5 +1,7 @@
 # Moog Agent Deployment
 
+Runs the [Moog](https://github.com/cardano-foundation/moog) agent against the team's preprod MPFS instance (`http://10.1.21.21:3000`). The agent mounts the host Docker socket and authenticates to the Antithesis registry with the credentials in `docker-config.json`.
+
 ## Setup
 
 ```bash
@@ -13,3 +15,9 @@ docker compose up -d
 ## Secrets
 
 Download all assets from 1Password: [assets](https://start.1password.com/open/i?a=TYQQQLKUDBAFVHQ4P7XKFCUVYM&v=fhipthmhnufti4q2kky6d7336u&i=pa22ff5xcxlusp7g4jhvvitnlq&h=cardanofoundation.1password.com)
+
+The compose file expects them at:
+
+- `/home/paolino/secrets/moog/agent/agent.json` — the agent wallet
+- `/home/paolino/secrets/moog/agent/secrets.yaml` — agent secrets (the expected keys are documented in the comments at the bottom of [docker-compose.yaml](docker-compose.yaml))
+- `/home/paolino/secrets/moog/agent/docker-config.json` — Docker registry credentials

--- a/infrastructure/moog/oracle/README.md
+++ b/infrastructure/moog/oracle/README.md
@@ -1,5 +1,7 @@
 # Moog Oracle Deployment
 
+Runs the [Moog](https://github.com/cardano-foundation/moog) oracle against the team's preprod MPFS instance (`http://10.1.21.21:3000`).
+
 ## Setup
 
 ```bash
@@ -13,3 +15,8 @@ docker compose up -d
 ## Secrets
 
 Download all assets from 1Password: [assets](https://start.1password.com/open/i?a=TYQQQLKUDBAFVHQ4P7XKFCUVYM&v=fhipthmhnufti4q2kky6d7336u&i=zcv5aijxrq3obq23ozzustghta&h=cardanofoundation.1password.com)
+
+The compose file expects them at:
+
+- `/home/paolino/secrets/moog/oracle/oracle.json` — the oracle wallet
+- `/home/paolino/secrets/moog/oracle/secrets.yaml` — oracle secrets

--- a/infrastructure/mpfs/README.md
+++ b/infrastructure/mpfs/README.md
@@ -2,6 +2,14 @@
 
 This directory contains the necessary files and instructions to deploy an MPFS system in preprod.
 
+## Prerequisites
+
+The compose file and the bootstrap script expect a few files that are not in the repository:
+
+- `.env` in this directory (gitignored), defining `MPFS_DIR` — the directory where the bootstrap script downloads the Mithril snapshot of the node database (the compose file mounts the node database from `/opt/mpfs/preprod/db`).
+- `/home/paolino/secrets/mpfs/.env` — environment file for the `yaci-store-preprod` container (database credentials).
+- `/home/paolino/secrets/mpfs/db-password` — password file for the `yaci-store-db-preprod` PostgreSQL container.
+
 ## Fresh setup
 
 To set up a fresh MPFS deployment, follow these steps:
@@ -19,12 +27,18 @@ source bootstrap.sh
 
 **Always deploy from `/opt/hal/infrastructure/mpfs/`.** Docker Compose resolves `./configs` relative to the working directory — running from any other location will cause containers to mount non-existent paths and crash on restart.
 
+The node configuration files in [configs/](configs) are the preprod environment files from [book.play.dev.cardano.org](https://book.play.dev.cardano.org/environments.html); refresh them with [configs/download.sh](configs/download.sh).
+
 ## Starting services
 
 ```bash
 cd /opt/hal/infrastructure/mpfs
 docker compose up -d
 ```
+
+## Monitoring
+
+A Gatus instance on the same host (see [../gatus/mpfs/](../gatus/mpfs)) checks MPFS sync, Ogmios, Yaci Store and node head freshness, and the cron-driven [node-currency-check.sh](../scripts/node-currency-check.sh) warns when the pinned `cardano-node` image falls behind the latest release.
 
 ## Bugs
 
@@ -37,5 +51,5 @@ curl http://localhost:3000/tokens
 Restarting the service seems to fix the issue:
 
 ```bash
-docker-compose restart mpfs
+docker compose restart mpfs
 ```

--- a/skills/hal-guide/SKILL.md
+++ b/skills/hal-guide/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: hal-guide
+description: Guide to the cardano-foundation/hal repository — the Cardano Foundation High Assurance Lab (HAL) team repo. Load when asked about the HAL team, its handbook, processes, weekly or monthly meeting notes, the projects table (cardano-wallet, cardano-addresses, moog, mpfs, amaru, vrf, kes, pop), ZKP/cryptography learning material, or the team's preprod infrastructure - the MPFS Docker Compose stack (cardano-node, Ogmios, Yaci Store, PostgreSQL), Moog agent/oracle deployments, Gatus monitoring, Telegram alerting, node-currency-check.sh, bootstrap.sh, Mithril snapshot bootstrap, files under infrastructure/ or docs/, or hosts 10.1.21.19/20/21.
+---
+
+# HAL repository guide
+
+## Repository map
+
+| Path | Purpose |
+|------|---------|
+| `README.md` | Entry point: what the repo is, projects table with statuses and versions, architecture diagram |
+| `docs/handbook.md` | How the team works: organisation, stack, git workflow, testing, open improvement topics |
+| `docs/weekly/`, `docs/monthly/` | Meeting notes (one file per week) and monthly reports |
+| `docs/async.md`, `docs/interviews.md`, `docs/2025-09-team-workshop.md` | Process documents and retrospectives |
+| `docs/radicle.md` | Radicle evaluation; ends with the November 2025 decision to stop using it |
+| `docs/homebrew.md` | How to add formulae to the team's Homebrew tap (notunrandom/homebrew-cardano) |
+| `docs/crypto/` | ZKP learning material: gitbook.md (SageMath/Rust/Zig exercises), journal.md, training slides |
+| `docs/deployment/anti-services.md` | Historical: pre-rename Moog ("anti") deployment; superseded by `infrastructure/moog/` |
+| `infrastructure/mpfs/` | Preprod MPFS compose stack: cardano-node, Ogmios, Yaci Store + PostgreSQL, MPFS, autoheal |
+| `infrastructure/moog/{agent,oracle}/` | Moog agent and oracle compose files, pinned to released images |
+| `infrastructure/gatus/{mpfs,agent,oracle}/` | Per-host Gatus monitoring configs with Telegram alerting |
+| `infrastructure/scripts/node-currency-check.sh` | Cron script alerting when a running cardano-node image lags the latest release |
+| `templates/README.md` | README template for new HAL projects |
+
+## Build, test, run
+
+Nothing builds or runs locally; there is no CI, no flake, no test suite. The only executable content is the deployment configuration, which runs on three CF preprod hosts from a `/opt/hal` checkout:
+
+- MPFS host (10.1.21.21): `cd /opt/hal/infrastructure/mpfs && docker compose up -d` (after the Mithril bootstrap and secret files described in `infrastructure/mpfs/README.md`)
+- Agent host (10.1.21.20): `cd /opt/hal/infrastructure/moog/agent && docker compose up -d`
+- Oracle host (10.1.21.19): `cd /opt/hal/infrastructure/moog/oracle && docker compose up -d`
+
+Do not run these on a development machine: they mount host paths (`/opt/mpfs/...`) and secret files (`/home/paolino/secrets/...`) that only exist on those hosts.
+
+## Navigating the code
+
+- For deployment facts (image versions, ports, networks, secrets paths), the compose files are the source of truth: `infrastructure/mpfs/docker-compose.yml`, `infrastructure/moog/*/docker-compose.yaml`, `infrastructure/gatus/*/docker-compose.yaml`.
+- Yaci Store indexer settings (sync start slot, enabled stores, Ogmios URL) are in `infrastructure/mpfs/application.properties`.
+- Monitoring conditions (what fires a Telegram alert) are in `infrastructure/gatus/*/config.yaml`.
+- The node config files in `infrastructure/mpfs/configs/` come from book.play.dev.cardano.org; `configs/download.sh` refreshes them.
+- Team decisions and their history live in `docs/` (handbook for current practice, weekly/monthly notes for when something changed).
+
+## Using the artifacts
+
+This repo is consumed by reading, not installing. Typical operations:
+
+- Deploy or update a service: follow the README next to its compose file (`infrastructure/{mpfs,moog/agent,moog/oracle}/README.md`); always `docker compose` from the `/opt/hal` checkout directory.
+- Bootstrap a fresh MPFS node database: `source infrastructure/mpfs/bootstrap.sh` (requires a local `.env` defining `MPFS_DIR`; downloads a Mithril preprod snapshot).
+- Check monitoring: Gatus web UI on the MPFS host listens on port 8090; alerts go to Telegram.
+- Test the currency check without sending alerts: `DRY_RUN=1 infrastructure/scripts/node-currency-check.sh <telegram-env-file>`.
+
+## Answering questions
+
+- "What does the HAL team work on?" → the Projects table in `README.md` (status icons + pinned versions; verify versions against GitHub releases before quoting them, they age).
+- "How does the team work / what's the process?" → `docs/handbook.md`; open questions are in its WIP section and in `docs/interviews.md`.
+- "What runs in preprod / what is deployed where?" → `infrastructure/README.md` (host table + architecture diagram), then the per-service compose files.
+- "Why did an alert fire?" → `infrastructure/gatus/*/config.yaml` for the condition; `infrastructure/scripts/node-currency-check.sh` for release-lag warnings.
+- "What is MPFS / Moog?" → one-liners in the Projects table; the real docs are in their own repos (cardano-foundation/mpfs, cardano-foundation/moog).
+- "Did the team adopt Radicle?" → no; `docs/radicle.md`, November 2025 decision.


### PR DESCRIPTION
Documentation review against the actual state of the repository, bringing it to the org-wide documentation standard. Docs-only diff (8 markdown files); no code, workflows, or compose logic touched.

## What was inaccurate

- **README project table held stale versions.** `cardano-wallet` showed `v2025-03-31` (latest is `v2026-05-11`), `cardano-addresses` showed `4.0.1` (latest `4.0.5`), `moog` showed `v0.4.1.1` (latest `v0.5.1.5`). `mpfs` had no version despite a `v1.3.0` release.
- **`pop` was marked 💡 (ideation)** but `cardano-scaling/pop` is archived; corrected to 💀 with a note.
- **README had no "What is this" section and no architecture diagram**, though the repo ships a real multi-service deployment under `infrastructure/`.
- **`docs/deployment/anti-services.md` was silently stale**: it documents the pre-rename "anti" (now Moog) services and a `rad push` step, but Moog is now deployed from `infrastructure/moog/` and the team dropped Radicle in November 2025.
- **`infrastructure/mpfs/README.md` omitted prerequisites** — the `.env` (`MPFS_DIR`) the bootstrap script sources and the two secret files the compose stack mounts — and referenced `docker-compose` (v1) for the restart command.
- **No agent layer** (`AGENTS.md` / `skills/`), required by the standard for every repo.

## What changed

- **README** rewritten into the standard section order (What is this / Projects / Architecture / Documentation / Development) with verified versions and a mermaid architecture diagram of the `infrastructure/` deployment.
- **`infrastructure/README.md`** added: host table (MPFS 10.1.21.21, Agent 10.1.21.20, Oracle 10.1.21.19), a node-by-node mermaid diagram, and a per-component walkthrough — all read from the compose files.
- **`infrastructure/mpfs/README.md`** documents the `.env` and secret-file prerequisites, the preprod config provenance, monitoring, and fixes the `docker compose restart` command.
- **`infrastructure/moog/{agent,oracle}/README.md`** state what each service does, the MPFS endpoint it targets, and the exact secret paths the compose file expects.
- **`docs/deployment/anti-services.md`** gains a "superseded" banner pointing to the current infrastructure and the Radicle decision.
- **`AGENTS.md` + `skills/hal-guide/SKILL.md`** added: repository map, where deployment facts live (compose files as source of truth), and where answers to common questions about the team and its preprod stack are found.

## How claims and diagrams were verified

- Project table versions checked against GitHub releases (`gh api repos/<r>/releases/latest`); `pop` archived state and repo descriptions checked via `gh api`.
- Every deployment fact (image tags, ports, networks, secret paths, host addresses, sync endpoints) read directly from `infrastructure/**/docker-compose.y*ml`, `application.properties`, and the gatus `config.yaml` files rather than from the prose.
- Both mermaid diagrams validated node-by-node and edge-by-edge against the compose topology and parsed with `mermaid.parse` (mermaid 11.x under a jsdom DOM, since the runner has no Chrome); no reserved `end` ids, balanced brackets/quotes.
- All relative links and section anchors in the changed files checked to resolve to existing files/headings.
- No `mkdocs.yml` in the repo, so no docs-site build applies.
